### PR TITLE
Automatic npm publish action

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,26 @@
+name: npm-publish
+on:
+  push:
+    branches:
+      - master
+jobs:
+  npm-publish:
+    name: npm-publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@master
+    - name: Set up Node.js
+      uses: actions/setup-node@master
+      with:
+        node-version: 10.0.0
+    - name: Publish if version has been updated
+      uses: pascalgn/npm-publish-action@06e0830ea83eea10ed4a62654eeaedafb8bf50fc
+      with: # All of theses inputs are optional
+        tag_name: "v%s"
+        tag_message: "v%s"
+        commit_pattern: "^Release (\\S+)"
+        workspace: "."
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Leave this as is, it's automatically generated
+        NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }} # You need to set this in your repo settings


### PR DESCRIPTION
Refer https://github.com/marketplace/actions/publish-to-npm. Adding their instruction to this PR to make it easier for you.

When someone changes the version in `package.json` to 1.2.3 and pushes a commit to master with the message `Release 1.2.3`, the `npm-publish` action will create a new tag `v1.2.3` and publish the package to the npm registry.

### Inputs
These inputs are optional: that means that if you don't enter them, default values will be used and it'll work just fine.

`tag_name`: the name pattern of the new tag
`tag_message`: the message pattern of the new tag
`commit_pattern`: the pattern that the commit message needs to follow
`workspace`: custom workspace directory that contains the package.json file

### Environment variables
`GITHUB_TOKEN`: this is a token that GitHub generates automatically, you only need to pass it to the action as in the example
`NPM_AUTH_TOKEN`: this is the token the action will use to authenticate to npm. You need to generate one in npm, then you can add it to your secrets (settings -> secrets) so that it can be passed to the action. DO NOT put the token directly in your workflow file.